### PR TITLE
ci: Enforces commit message linting via Husky and commitlint

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,36 +1,27 @@
 name: Commit Lint
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   commitlint:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Install required dependencies
-        run: |
-          sudo apt update
-          sudo apt install -y sudo
-          sudo apt install -y git curl
-          curl -sL https://deb.nodesource.com/setup_18.x | sudo -E bash -
-          sudo DEBIAN_FRONTEND=noninteractive apt install -y nodejs
-      - name: Print versions
-        run: |
-          git --version
-          node --version
-          npm --version
-          npx commitlint --version
-      - name: Install commitlint
-        run: |
-          npm install conventional-changelog-conventionalcommits
-          npm install commitlint@latest
+      # Setup Deno environment
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Install Dependencies
+        run: deno install
 
       - name: Validate current commit (last commit) with commitlint
         if: github.event_name == 'push'
-        run: npx commitlint --last --verbose
+        run: deno task --eval commitlint --last --verbose
 
       - name: Validate PR commits with commitlint
         if: github.event_name == 'pull_request'
-        run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
+        run: deno task --eval commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -11,8 +11,8 @@ jobs:
           fetch-depth: 0
       - name: Install required dependencies
         run: |
-          apt update
-          apt install -y sudo
+          sudo apt update
+          sudo apt install -y sudo
           sudo apt install -y git curl
           curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
           sudo DEBIAN_FRONTEND=noninteractive apt install -y nodejs
@@ -34,4 +34,3 @@ jobs:
       - name: Validate PR commits with commitlint
         if: github.event_name == 'pull_request'
         run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
-        

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,37 @@
+name: Commit Lint
+
+on: [push, pull_request]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install required dependencies
+        run: |
+          apt update
+          apt install -y sudo
+          sudo apt install -y git curl
+          curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
+          sudo DEBIAN_FRONTEND=noninteractive apt install -y nodejs
+      - name: Print versions
+        run: |
+          git --version
+          node --version
+          npm --version
+          npx commitlint --version
+      - name: Install commitlint
+        run: |
+          npm install conventional-changelog-conventionalcommits
+          npm install commitlint@latest
+
+      - name: Validate current commit (last commit) with commitlint
+        if: github.event_name == 'push'
+        run: npx commitlint --last --verbose
+
+      - name: Validate PR commits with commitlint
+        if: github.event_name == 'pull_request'
+        run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
+        

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -14,7 +14,7 @@ jobs:
           sudo apt update
           sudo apt install -y sudo
           sudo apt install -y git curl
-          curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
+          curl -sL https://deb.nodesource.com/setup_18.x | sudo -E bash -
           sudo DEBIAN_FRONTEND=noninteractive apt install -y nodejs
       - name: Print versions
         run: |

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "header-max-length": [1, "always", 160],
+  },
+  helpUrl: "https://www.conventionalcommits.org/",
+};

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+module.exports = { 
   extends: ["@commitlint/config-conventional"],
   rules: {
     "header-max-length": [1, "always", 160],

--- a/deno.json
+++ b/deno.json
@@ -12,11 +12,14 @@
     "semantic-release": "semantic-release"
   },
   "imports": {
+    "@commitlint/cli": "npm:@commitlint/cli@^19.8.0",
+    "@commitlint/config-conventional": "npm:@commitlint/config-conventional@^19.8.0",
     "@deno/dnt": "jsr:@deno/dnt@^0.41.3",
     "@sebbo2002/semantic-release-jsr": "npm:@sebbo2002/semantic-release-jsr@^2.0.5",
     "@semantic-release/git": "npm:@semantic-release/git@^10.0.1",
     "@semantic-release/npm": "npm:@semantic-release/npm@^12.0.1",
     "@std/assert": "jsr:@std/assert@1",
+    "husky": "npm:husky@^9.1.7",
     "lightningcss-wasm": "npm:lightningcss-wasm@^1.29.1",
     "semantic-release": "npm:semantic-release@^24.2.3",
     "xxhash-wasm": "npm:xxhash-wasm@^1.1.0",

--- a/deno.json
+++ b/deno.json
@@ -9,7 +9,8 @@
     "lint": "deno lint",
     "fmt": "deno fmt",
     "build:npm": "deno run -A ./scripts/build-npm.ts",
-    "semantic-release": "semantic-release"
+    "semantic-release": "semantic-release",
+    "commitlint": "commitlint"
   },
   "imports": {
     "@commitlint/cli": "npm:@commitlint/cli@^19.8.0",

--- a/deno.lock
+++ b/deno.lock
@@ -27,9 +27,15 @@
     "jsr:@std/testing@*": "1.0.10",
     "jsr:@ts-morph/bootstrap@0.24": "0.24.0",
     "jsr:@ts-morph/common@0.24": "0.24.0",
+    "npm:@commitlint/cli@*": "19.8.0",
+    "npm:@commitlint/cli@19.8.0": "19.8.0",
+    "npm:@commitlint/cli@^19.8.0": "19.8.0",
+    "npm:@commitlint/config-conventional@^19.8.0": "19.8.0",
     "npm:@sebbo2002/semantic-release-jsr@^2.0.5": "2.0.5",
     "npm:@semantic-release/git@^10.0.1": "10.0.1_semantic-release@24.2.3__marked@12.0.2",
     "npm:@semantic-release/npm@^12.0.1": "12.0.1_semantic-release@24.2.3__marked@12.0.2",
+    "npm:husky@9.1.7": "9.1.7",
+    "npm:husky@^9.1.7": "9.1.7",
     "npm:lightningcss-wasm@^1.29.1": "1.29.1",
     "npm:semantic-release@^24.2.3": "24.2.3_marked@12.0.2",
     "npm:xxhash-wasm@^1.1.0": "1.1.0"
@@ -170,15 +176,150 @@
     "@colors/colors@1.5.0": {
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
     },
+    "@commitlint/cli@19.8.0": {
+      "integrity": "sha512-t/fCrLVu+Ru01h0DtlgHZXbHV2Y8gKocTR5elDOqIRUzQd0/6hpt2VIWOj9b3NDo7y4/gfxeR2zRtXq/qO6iUg==",
+      "dependencies": [
+        "@commitlint/format",
+        "@commitlint/lint",
+        "@commitlint/load",
+        "@commitlint/read",
+        "@commitlint/types",
+        "tinyexec",
+        "yargs@17.7.2"
+      ]
+    },
+    "@commitlint/config-conventional@19.8.0": {
+      "integrity": "sha512-9I2kKJwcAPwMoAj38hwqFXG0CzS2Kj+SAByPUQ0SlHTfb7VUhYVmo7G2w2tBrqmOf7PFd6MpZ/a1GQJo8na8kw==",
+      "dependencies": [
+        "@commitlint/types",
+        "conventional-changelog-conventionalcommits"
+      ]
+    },
+    "@commitlint/config-validator@19.8.0": {
+      "integrity": "sha512-+r5ZvD/0hQC3w5VOHJhGcCooiAVdynFlCe2d6I9dU+PvXdV3O+fU4vipVg+6hyLbQUuCH82mz3HnT/cBQTYYuA==",
+      "dependencies": [
+        "@commitlint/types",
+        "ajv"
+      ]
+    },
+    "@commitlint/ensure@19.8.0": {
+      "integrity": "sha512-kNiNU4/bhEQ/wutI1tp1pVW1mQ0QbAjfPRo5v8SaxoVV+ARhkB8Wjg3BSseNYECPzWWfg/WDqQGIfV1RaBFQZg==",
+      "dependencies": [
+        "@commitlint/types",
+        "lodash.camelcase",
+        "lodash.kebabcase",
+        "lodash.snakecase",
+        "lodash.startcase",
+        "lodash.upperfirst"
+      ]
+    },
+    "@commitlint/execute-rule@19.8.0": {
+      "integrity": "sha512-fuLeI+EZ9x2v/+TXKAjplBJWI9CNrHnyi5nvUQGQt4WRkww/d95oVRsc9ajpt4xFrFmqMZkd/xBQHZDvALIY7A=="
+    },
+    "@commitlint/format@19.8.0": {
+      "integrity": "sha512-EOpA8IERpQstxwp/WGnDArA7S+wlZDeTeKi98WMOvaDLKbjptuHWdOYYr790iO7kTCif/z971PKPI2PkWMfOxg==",
+      "dependencies": [
+        "@commitlint/types",
+        "chalk@5.4.1"
+      ]
+    },
+    "@commitlint/is-ignored@19.8.0": {
+      "integrity": "sha512-L2Jv9yUg/I+jF3zikOV0rdiHUul9X3a/oU5HIXhAJLE2+TXTnEBfqYP9G5yMw/Yb40SnR764g4fyDK6WR2xtpw==",
+      "dependencies": [
+        "@commitlint/types",
+        "semver"
+      ]
+    },
+    "@commitlint/lint@19.8.0": {
+      "integrity": "sha512-+/NZKyWKSf39FeNpqhfMebmaLa1P90i1Nrb1SrA7oSU5GNN/lksA4z6+ZTnsft01YfhRZSYMbgGsARXvkr/VLQ==",
+      "dependencies": [
+        "@commitlint/is-ignored",
+        "@commitlint/parse",
+        "@commitlint/rules",
+        "@commitlint/types"
+      ]
+    },
+    "@commitlint/load@19.8.0_cosmiconfig@9.0.0__typescript@5.8.2": {
+      "integrity": "sha512-4rvmm3ff81Sfb+mcWT5WKlyOa+Hd33WSbirTVUer0wjS1Hv/Hzr07Uv1ULIV9DkimZKNyOwXn593c+h8lsDQPQ==",
+      "dependencies": [
+        "@commitlint/config-validator",
+        "@commitlint/execute-rule",
+        "@commitlint/resolve-extends",
+        "@commitlint/types",
+        "chalk@5.4.1",
+        "cosmiconfig-typescript-loader",
+        "cosmiconfig@9.0.0_typescript@5.8.2",
+        "lodash.isplainobject",
+        "lodash.merge",
+        "lodash.uniq"
+      ]
+    },
+    "@commitlint/message@19.8.0": {
+      "integrity": "sha512-qs/5Vi9bYjf+ZV40bvdCyBn5DvbuelhR6qewLE8Bh476F7KnNyLfdM/ETJ4cp96WgeeHo6tesA2TMXS0sh5X4A=="
+    },
+    "@commitlint/parse@19.8.0": {
+      "integrity": "sha512-YNIKAc4EXvNeAvyeEnzgvm1VyAe0/b3Wax7pjJSwXuhqIQ1/t2hD3OYRXb6D5/GffIvaX82RbjD+nWtMZCLL7Q==",
+      "dependencies": [
+        "@commitlint/types",
+        "conventional-changelog-angular@7.0.0",
+        "conventional-commits-parser@5.0.0"
+      ]
+    },
+    "@commitlint/read@19.8.0": {
+      "integrity": "sha512-6ywxOGYajcxK1y1MfzrOnwsXO6nnErna88gRWEl3qqOOP8MDu/DTeRkGLXBFIZuRZ7mm5yyxU5BmeUvMpNte5w==",
+      "dependencies": [
+        "@commitlint/top-level",
+        "@commitlint/types",
+        "git-raw-commits",
+        "minimist",
+        "tinyexec"
+      ]
+    },
+    "@commitlint/resolve-extends@19.8.0": {
+      "integrity": "sha512-CLanRQwuG2LPfFVvrkTrBR/L/DMy3+ETsgBqW1OvRxmzp/bbVJW0Xw23LnnExgYcsaFtos967lul1CsbsnJlzQ==",
+      "dependencies": [
+        "@commitlint/config-validator",
+        "@commitlint/types",
+        "global-directory",
+        "import-meta-resolve",
+        "lodash.mergewith",
+        "resolve-from@5.0.0"
+      ]
+    },
+    "@commitlint/rules@19.8.0": {
+      "integrity": "sha512-IZ5IE90h6DSWNuNK/cwjABLAKdy8tP8OgGVGbXe1noBEX5hSsu00uRlLu6JuruiXjWJz2dZc+YSw3H0UZyl/mA==",
+      "dependencies": [
+        "@commitlint/ensure",
+        "@commitlint/message",
+        "@commitlint/to-lines",
+        "@commitlint/types"
+      ]
+    },
+    "@commitlint/to-lines@19.8.0": {
+      "integrity": "sha512-3CKLUw41Cur8VMjh16y8LcsOaKbmQjAKCWlXx6B0vOUREplp6em9uIVhI8Cv934qiwkbi2+uv+mVZPnXJi1o9A=="
+    },
+    "@commitlint/top-level@19.8.0": {
+      "integrity": "sha512-Rphgoc/omYZisoNkcfaBRPQr4myZEHhLPx2/vTXNLjiCw4RgfPR1wEgUpJ9OOmDCiv5ZyIExhprNLhteqH4FuQ==",
+      "dependencies": [
+        "find-up@7.0.0"
+      ]
+    },
+    "@commitlint/types@19.8.0": {
+      "integrity": "sha512-LRjP623jPyf3Poyfb0ohMj8I3ORyBDOwXAgxxVPbSD0unJuW2mJWeiRfaQinjtccMqC5Wy1HOMfa4btKjbNxbg==",
+      "dependencies": [
+        "@types/conventional-commits-parser",
+        "chalk@5.4.1"
+      ]
+    },
     "@isaacs/cliui@8.0.2": {
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "dependencies": [
-        "string-width@5.1.2",
         "string-width-cjs@npm:string-width@4.2.3",
-        "strip-ansi@7.1.0",
+        "string-width@5.1.2",
         "strip-ansi-cjs@npm:strip-ansi@6.0.1",
-        "wrap-ansi@8.1.0",
-        "wrap-ansi-cjs@npm:wrap-ansi@7.0.0"
+        "strip-ansi@7.1.0",
+        "wrap-ansi-cjs@npm:wrap-ansi@7.0.0",
+        "wrap-ansi@8.1.0"
       ]
     },
     "@isaacs/fs-minipass@4.0.1": {
@@ -470,15 +611,29 @@
     "@semantic-release/commit-analyzer@13.0.1_semantic-release@24.2.3__marked@12.0.2_marked@12.0.2": {
       "integrity": "sha512-wdnBPHKkr9HhNhXOhZD5a2LNl91+hs8CC2vsAVYxtZH3y0dV3wKn+uZSN61rdJQZ8EGxzWB3inWocBHV9+u/CQ==",
       "dependencies": [
-        "conventional-changelog-angular",
+        "conventional-changelog-angular@8.0.0",
         "conventional-changelog-writer",
         "conventional-commits-filter",
-        "conventional-commits-parser",
+        "conventional-commits-parser@6.1.0",
         "debug",
         "import-from-esm",
         "lodash-es",
         "micromatch",
-        "semantic-release"
+        "semantic-release@24.2.3_marked@12.0.2"
+      ]
+    },
+    "@semantic-release/commit-analyzer@13.0.1_semantic-release@24.2.3__marked@12.0.2_marked@12.0.2_@octokit+core@6.1.4": {
+      "integrity": "sha512-wdnBPHKkr9HhNhXOhZD5a2LNl91+hs8CC2vsAVYxtZH3y0dV3wKn+uZSN61rdJQZ8EGxzWB3inWocBHV9+u/CQ==",
+      "dependencies": [
+        "conventional-changelog-angular@8.0.0",
+        "conventional-changelog-writer",
+        "conventional-commits-filter",
+        "conventional-commits-parser@6.1.0",
+        "debug",
+        "import-from-esm",
+        "lodash-es",
+        "micromatch",
+        "semantic-release@24.2.3_marked@12.0.2_@octokit+core@6.1.4"
       ]
     },
     "@semantic-release/error@3.0.0": {
@@ -498,7 +653,7 @@
         "lodash",
         "micromatch",
         "p-reduce@2.1.0",
-        "semantic-release"
+        "semantic-release@24.2.3_marked@12.0.2"
       ]
     },
     "@semantic-release/github@11.0.1_semantic-release@24.2.3__marked@12.0.2_marked@12.0.2_@octokit+core@6.1.4": {
@@ -519,7 +674,7 @@
         "lodash-es",
         "mime",
         "p-filter",
-        "semantic-release",
+        "semantic-release@24.2.3_marked@12.0.2_@octokit+core@6.1.4",
         "url-join"
       ]
     },
@@ -537,7 +692,7 @@
         "rc",
         "read-pkg",
         "registry-auth-token",
-        "semantic-release",
+        "semantic-release@24.2.3_marked@12.0.2",
         "semver",
         "tempy"
       ]
@@ -556,7 +711,26 @@
         "rc",
         "read-pkg",
         "registry-auth-token",
-        "semantic-release",
+        "semantic-release@24.2.3_marked@12.0.2",
+        "semver",
+        "tempy"
+      ]
+    },
+    "@semantic-release/npm@12.0.1_semantic-release@24.2.3__marked@12.0.2_marked@12.0.2_@octokit+core@6.1.4": {
+      "integrity": "sha512-/6nntGSUGK2aTOI0rHPwY3ZjgY9FkXmEHbW9Kr+62NVOsyqpKKeP0lrCH+tphv+EsNdJNmqqwijTEnVWUMQ2Nw==",
+      "dependencies": [
+        "@semantic-release/error@4.0.0",
+        "aggregate-error@5.0.0",
+        "execa@9.5.2",
+        "fs-extra",
+        "lodash-es",
+        "nerf-dart",
+        "normalize-url",
+        "npm",
+        "rc",
+        "read-pkg",
+        "registry-auth-token",
+        "semantic-release@24.2.3_marked@12.0.2_@octokit+core@6.1.4",
         "semver",
         "tempy"
       ]
@@ -564,17 +738,33 @@
     "@semantic-release/release-notes-generator@14.0.3_semantic-release@24.2.3__marked@12.0.2_marked@12.0.2": {
       "integrity": "sha512-XxAZRPWGwO5JwJtS83bRdoIhCiYIx8Vhr+u231pQAsdFIAbm19rSVJLdnBN+Avvk7CKvNQE/nJ4y7uqKH6WTiw==",
       "dependencies": [
-        "conventional-changelog-angular",
+        "conventional-changelog-angular@8.0.0",
         "conventional-changelog-writer",
         "conventional-commits-filter",
-        "conventional-commits-parser",
+        "conventional-commits-parser@6.1.0",
         "debug",
         "get-stream@7.0.1",
         "import-from-esm",
         "into-stream",
         "lodash-es",
         "read-package-up",
-        "semantic-release"
+        "semantic-release@24.2.3_marked@12.0.2"
+      ]
+    },
+    "@semantic-release/release-notes-generator@14.0.3_semantic-release@24.2.3__marked@12.0.2_marked@12.0.2_@octokit+core@6.1.4": {
+      "integrity": "sha512-XxAZRPWGwO5JwJtS83bRdoIhCiYIx8Vhr+u231pQAsdFIAbm19rSVJLdnBN+Avvk7CKvNQE/nJ4y7uqKH6WTiw==",
+      "dependencies": [
+        "conventional-changelog-angular@8.0.0",
+        "conventional-changelog-writer",
+        "conventional-commits-filter",
+        "conventional-commits-parser@6.1.0",
+        "debug",
+        "get-stream@7.0.1",
+        "import-from-esm",
+        "into-stream",
+        "lodash-es",
+        "read-package-up",
+        "semantic-release@24.2.3_marked@12.0.2_@octokit+core@6.1.4"
       ]
     },
     "@sigstore/bundle@3.1.0": {
@@ -634,8 +824,27 @@
         "minimatch"
       ]
     },
+    "@types/conventional-commits-parser@5.0.1": {
+      "integrity": "sha512-7uz5EHdzz2TqoMfV7ee61Egf5y6NkcO4FB/1iCCQnbeiI1F3xzv3vK5dBCXUCLQgGYS+mUeigK1iKQzvED+QnQ==",
+      "dependencies": [
+        "@types/node"
+      ]
+    },
+    "@types/node@22.12.0": {
+      "integrity": "sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==",
+      "dependencies": [
+        "undici-types"
+      ]
+    },
     "@types/normalize-package-data@2.4.4": {
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="
+    },
+    "JSONStream@1.3.5": {
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dependencies": [
+        "jsonparse",
+        "through"
+      ]
     },
     "abbrev@3.0.0": {
       "integrity": "sha512-+/kfrslGQ7TNV2ecmQwMJj/B65g5KVq1/L3SGVZ3tCYGqlzFuFCGBZJtMP99wH3NpEUyAjn0zPdPUg0D+DwrOA=="
@@ -655,6 +864,15 @@
       "dependencies": [
         "clean-stack@5.2.0",
         "indent-string@5.0.0"
+      ]
+    },
+    "ajv@8.17.1": {
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dependencies": [
+        "fast-deep-equal",
+        "fast-uri",
+        "json-schema-traverse",
+        "require-from-string"
       ]
     },
     "ansi-escapes@7.0.0": {
@@ -743,10 +961,10 @@
         "fs-minipass@3.0.3",
         "glob",
         "lru-cache",
-        "minipass@7.1.2",
         "minipass-collect",
         "minipass-flush",
         "minipass-pipeline",
+        "minipass@7.1.2",
         "p-map@7.0.3",
         "ssri",
         "tar@7.4.3",
@@ -814,8 +1032,8 @@
         "chalk@4.1.2",
         "highlight.js",
         "mz",
-        "parse5@5.1.1",
         "parse5-htmlparser2-tree-adapter",
+        "parse5@5.1.1",
         "yargs@16.2.0"
       ]
     },
@@ -880,8 +1098,20 @@
         "proto-list"
       ]
     },
+    "conventional-changelog-angular@7.0.0": {
+      "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
+      "dependencies": [
+        "compare-func"
+      ]
+    },
     "conventional-changelog-angular@8.0.0": {
       "integrity": "sha512-CLf+zr6St0wIxos4bmaKHRXWAcsCXrJU6F4VdNDrGRK3B8LDLKoX3zuMV5GhtbGkVR/LohZ6MT6im43vZLSjmA==",
+      "dependencies": [
+        "compare-func"
+      ]
+    },
+    "conventional-changelog-conventionalcommits@7.0.2": {
+      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
       "dependencies": [
         "compare-func"
       ]
@@ -891,17 +1121,26 @@
       "dependencies": [
         "conventional-commits-filter",
         "handlebars",
-        "meow",
+        "meow@13.2.0",
         "semver"
       ]
     },
     "conventional-commits-filter@5.0.0": {
       "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q=="
     },
+    "conventional-commits-parser@5.0.0": {
+      "integrity": "sha512-ZPMl0ZJbw74iS9LuX9YIAiW8pfM5p3yh2o/NbXHbkFuZzY5jvdi5jFycEOkmBW5H5I7nA+D6f3UcsCLP2vvSEA==",
+      "dependencies": [
+        "JSONStream",
+        "is-text-path",
+        "meow@12.1.1",
+        "split2@4.2.0"
+      ]
+    },
     "conventional-commits-parser@6.1.0": {
       "integrity": "sha512-5nxDo7TwKB5InYBl4ZC//1g9GRwB/F3TXOGR9hgUjMGfvSP4Vu5NkpNro2+1+TIEy1vwxApl5ircECr2ri5JIw==",
       "dependencies": [
-        "meow"
+        "meow@13.2.0"
       ]
     },
     "convert-hrtime@5.0.0": {
@@ -910,6 +1149,15 @@
     "core-util-is@1.0.3": {
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
+    "cosmiconfig-typescript-loader@6.1.0_@types+node@22.12.0_cosmiconfig@9.0.0__typescript@5.8.2_typescript@5.8.2": {
+      "integrity": "sha512-tJ1w35ZRUiM5FeTzT7DtYWAFFv37ZLqSRkGi2oeCK1gPhvaWjkAtfXvLmvE1pRfxxp9aQo6ba/Pvg1dKj05D4g==",
+      "dependencies": [
+        "@types/node",
+        "cosmiconfig@9.0.0_typescript@5.8.2",
+        "jiti",
+        "typescript"
+      ]
+    },
     "cosmiconfig@9.0.0": {
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dependencies": [
@@ -917,6 +1165,16 @@
         "import-fresh",
         "js-yaml",
         "parse-json@5.2.0"
+      ]
+    },
+    "cosmiconfig@9.0.0_typescript@5.8.2": {
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "dependencies": [
+        "env-paths",
+        "import-fresh",
+        "js-yaml",
+        "parse-json@5.2.0",
+        "typescript"
       ]
     },
     "cross-spawn@7.0.6": {
@@ -935,6 +1193,9 @@
     },
     "cssesc@3.0.0": {
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
+    },
+    "dargs@8.1.0": {
+      "integrity": "sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw=="
     },
     "debug@4.4.0": {
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
@@ -1066,6 +1327,9 @@
     "fast-content-type-parse@2.0.1": {
       "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q=="
     },
+    "fast-deep-equal@3.1.3": {
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
     "fast-glob@3.3.3": {
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dependencies": [
@@ -1075,6 +1339,9 @@
         "merge2",
         "micromatch"
       ]
+    },
+    "fast-uri@3.0.6": {
+      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw=="
     },
     "fastest-levenshtein@1.0.16": {
       "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg=="
@@ -1109,7 +1376,15 @@
     "find-up@2.1.0": {
       "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
       "dependencies": [
-        "locate-path"
+        "locate-path@2.0.0"
+      ]
+    },
+    "find-up@7.0.0": {
+      "integrity": "sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==",
+      "dependencies": [
+        "locate-path@7.2.0",
+        "path-exists@5.0.0",
+        "unicorn-magic@0.1.0"
       ]
     },
     "find-versions@6.0.0": {
@@ -1180,10 +1455,18 @@
       "dependencies": [
         "argv-formatter",
         "spawn-error-forwarder",
-        "split2",
+        "split2@1.0.0",
         "stream-combiner2",
         "through2",
         "traverse"
+      ]
+    },
+    "git-raw-commits@4.0.0": {
+      "integrity": "sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==",
+      "dependencies": [
+        "dargs",
+        "meow@12.1.1",
+        "split2@4.2.0"
       ]
     },
     "glob-parent@5.1.2": {
@@ -1201,6 +1484,12 @@
         "minipass@7.1.2",
         "package-json-from-dist",
         "path-scurry"
+      ]
+    },
+    "global-directory@4.0.1": {
+      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+      "dependencies": [
+        "ini@4.1.1"
       ]
     },
     "globby@14.1.0": {
@@ -1280,6 +1569,9 @@
     "human-signals@8.0.1": {
       "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="
     },
+    "husky@9.1.7": {
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="
+    },
     "iconv-lite@0.6.3": {
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dependencies": [
@@ -1329,6 +1621,9 @@
     },
     "ini@1.3.8": {
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
+    "ini@4.1.1": {
+      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g=="
     },
     "ini@5.0.0": {
       "integrity": "sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw=="
@@ -1401,6 +1696,12 @@
     "is-stream@4.0.1": {
       "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="
     },
+    "is-text-path@2.0.0": {
+      "integrity": "sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==",
+      "dependencies": [
+        "text-extensions"
+      ]
+    },
     "is-unicode-supported@2.1.0": {
       "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="
     },
@@ -1433,6 +1734,9 @@
     "java-properties@1.0.2": {
       "integrity": "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ=="
     },
+    "jiti@2.4.2": {
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A=="
+    },
     "js-tokens@4.0.0": {
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
@@ -1453,6 +1757,9 @@
     },
     "json-parse-even-better-errors@4.0.0": {
       "integrity": "sha512-lR4MXjGNgkJc7tkQ97kb2nuEMnNCyU//XYVH0MKTGcXEiSudQ5MKGKen3C5QubYy0vmq+JGitUg92uuywGEwIA=="
+    },
+    "json-schema-traverse@1.0.0": {
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "json-stringify-nice@1.1.4": {
       "integrity": "sha512-5Z5RFW63yxReJ7vANgW6eZFGWaQvnPE3WNmZoOJrSkGju2etKA2L5rrOa1sm877TVTFt57A80BH1bArcmlLfPw=="
@@ -1605,12 +1912,21 @@
     "locate-path@2.0.0": {
       "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
       "dependencies": [
-        "p-locate",
-        "path-exists"
+        "p-locate@2.0.0",
+        "path-exists@3.0.0"
+      ]
+    },
+    "locate-path@7.2.0": {
+      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+      "dependencies": [
+        "p-locate@6.0.0"
       ]
     },
     "lodash-es@4.17.21": {
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
+    "lodash.camelcase@4.3.0": {
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
     "lodash.capitalize@4.2.1": {
       "integrity": "sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw=="
@@ -1624,8 +1940,29 @@
     "lodash.isstring@4.0.1": {
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
     },
+    "lodash.kebabcase@4.1.1": {
+      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g=="
+    },
+    "lodash.merge@4.6.2": {
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "lodash.mergewith@4.6.2": {
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
+    },
+    "lodash.snakecase@4.1.1": {
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
+    },
+    "lodash.startcase@4.4.0": {
+      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg=="
+    },
+    "lodash.uniq@4.5.0": {
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
+    },
     "lodash.uniqby@4.7.0": {
       "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww=="
+    },
+    "lodash.upperfirst@4.3.1": {
+      "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg=="
     },
     "lodash@4.17.21": {
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
@@ -1639,10 +1976,10 @@
         "@npmcli/agent",
         "cacache",
         "http-cache-semantics",
-        "minipass@7.1.2",
         "minipass-fetch",
         "minipass-flush",
         "minipass-pipeline",
+        "minipass@7.1.2",
         "negotiator",
         "proc-log",
         "promise-retry",
@@ -1664,6 +2001,9 @@
     },
     "marked@12.0.2": {
       "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q=="
+    },
+    "meow@12.1.1": {
+      "integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw=="
     },
     "meow@13.2.0": {
       "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA=="
@@ -1709,8 +2049,8 @@
       "integrity": "sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==",
       "dependencies": [
         "encoding",
-        "minipass@7.1.2",
         "minipass-sized",
+        "minipass@7.1.2",
         "minizlib@3.0.1"
       ]
     },
@@ -1897,8 +2237,8 @@
         "@npmcli/redact",
         "jsonparse",
         "make-fetch-happen",
-        "minipass@7.1.2",
         "minipass-fetch",
+        "minipass@7.1.2",
         "minizlib@3.0.1",
         "npm-package-arg",
         "proc-log"
@@ -1967,8 +2307,8 @@
         "libnpmversion",
         "make-fetch-happen",
         "minimatch",
-        "minipass@7.1.2",
         "minipass-pipeline",
+        "minipass@7.1.2",
         "ms",
         "node-gyp",
         "nopt",
@@ -2032,10 +2372,22 @@
         "p-try"
       ]
     },
+    "p-limit@4.0.0": {
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "dependencies": [
+        "yocto-queue"
+      ]
+    },
     "p-locate@2.0.0": {
       "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
       "dependencies": [
-        "p-limit"
+        "p-limit@1.3.0"
+      ]
+    },
+    "p-locate@6.0.0": {
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+      "dependencies": [
+        "p-limit@4.0.0"
       ]
     },
     "p-map@4.0.0": {
@@ -2159,6 +2511,9 @@
     "path-exists@3.0.0": {
       "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="
     },
+    "path-exists@5.0.0": {
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ=="
+    },
     "path-key@3.1.1": {
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
@@ -2190,7 +2545,7 @@
     "pkg-conf@2.1.0": {
       "integrity": "sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==",
       "dependencies": [
-        "find-up",
+        "find-up@2.1.0",
         "load-json-file"
       ]
     },
@@ -2308,6 +2663,9 @@
     "require-directory@2.1.1": {
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
     },
+    "require-from-string@2.0.2": {
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
     "resolve-from@4.0.0": {
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
     },
@@ -2341,13 +2699,47 @@
     "semantic-release@24.2.3_marked@12.0.2": {
       "integrity": "sha512-KRhQG9cUazPavJiJEFIJ3XAMjgfd0fcK3B+T26qOl8L0UG5aZUjeRfREO0KM5InGtYwxqiiytkJrbcYoLDEv0A==",
       "dependencies": [
-        "@semantic-release/commit-analyzer",
+        "@semantic-release/commit-analyzer@13.0.1_semantic-release@24.2.3__marked@12.0.2_marked@12.0.2",
         "@semantic-release/error@4.0.0",
         "@semantic-release/github",
         "@semantic-release/npm@12.0.1_semantic-release@24.2.3__marked@12.0.2_marked@12.0.2",
-        "@semantic-release/release-notes-generator",
+        "@semantic-release/release-notes-generator@14.0.3_semantic-release@24.2.3__marked@12.0.2_marked@12.0.2",
         "aggregate-error@5.0.0",
-        "cosmiconfig",
+        "cosmiconfig@9.0.0_typescript@5.8.2",
+        "debug",
+        "env-ci",
+        "execa@9.5.2",
+        "figures@6.1.0",
+        "find-versions",
+        "get-stream@6.0.1",
+        "git-log-parser",
+        "hook-std",
+        "hosted-git-info@8.0.2",
+        "import-from-esm",
+        "lodash-es",
+        "marked",
+        "marked-terminal",
+        "micromatch",
+        "p-each-series",
+        "p-reduce@3.0.0",
+        "read-package-up",
+        "resolve-from@5.0.0",
+        "semver",
+        "semver-diff",
+        "signale",
+        "yargs@17.7.2"
+      ]
+    },
+    "semantic-release@24.2.3_marked@12.0.2_@octokit+core@6.1.4": {
+      "integrity": "sha512-KRhQG9cUazPavJiJEFIJ3XAMjgfd0fcK3B+T26qOl8L0UG5aZUjeRfREO0KM5InGtYwxqiiytkJrbcYoLDEv0A==",
+      "dependencies": [
+        "@semantic-release/commit-analyzer@13.0.1_semantic-release@24.2.3__marked@12.0.2_marked@12.0.2_@octokit+core@6.1.4",
+        "@semantic-release/error@4.0.0",
+        "@semantic-release/github",
+        "@semantic-release/npm@12.0.1_semantic-release@24.2.3__marked@12.0.2_marked@12.0.2_@octokit+core@6.1.4",
+        "@semantic-release/release-notes-generator@14.0.3_semantic-release@24.2.3__marked@12.0.2_marked@12.0.2_@octokit+core@6.1.4",
+        "aggregate-error@5.0.0",
+        "cosmiconfig@9.0.0_typescript@5.8.2",
         "debug",
         "env-ci",
         "execa@9.5.2",
@@ -2487,6 +2879,9 @@
         "through2"
       ]
     },
+    "split2@4.2.0": {
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="
+    },
     "sprintf-js@1.1.3": {
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
     },
@@ -2615,6 +3010,9 @@
         "unique-string"
       ]
     },
+    "text-extensions@2.4.0": {
+      "integrity": "sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g=="
+    },
     "text-table@0.2.0": {
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
     },
@@ -2637,6 +3035,9 @@
         "xtend"
       ]
     },
+    "through@2.3.8": {
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    },
     "time-span@5.1.0": {
       "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
       "dependencies": [
@@ -2645,6 +3046,9 @@
     },
     "tiny-relative-date@1.3.0": {
       "integrity": "sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A=="
+    },
+    "tinyexec@0.3.2": {
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="
     },
     "to-regex-range@5.0.1": {
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
@@ -2675,8 +3079,14 @@
     "type-fest@4.38.0": {
       "integrity": "sha512-2dBz5D5ycHIoliLYLi0Q2V7KRaDlH0uWIvmk7TYlAg5slqwiPv1ezJdZm1QEM0xgk29oYWMCbIG7E6gHpvChlg=="
     },
+    "typescript@5.8.2": {
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ=="
+    },
     "uglify-js@3.19.3": {
       "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="
+    },
+    "undici-types@6.20.0": {
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
     },
     "unicode-emoji-modifier-base@1.0.0": {
       "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g=="
@@ -2813,6 +3223,9 @@
         "yargs-parser@21.1.1"
       ]
     },
+    "yocto-queue@1.2.1": {
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg=="
+    },
     "yoctocolors@2.1.1": {
       "integrity": "sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ=="
     }
@@ -2821,9 +3234,12 @@
     "dependencies": [
       "jsr:@deno/dnt@~0.41.3",
       "jsr:@std/assert@1",
+      "npm:@commitlint/cli@^19.8.0",
+      "npm:@commitlint/config-conventional@^19.8.0",
       "npm:@sebbo2002/semantic-release-jsr@^2.0.5",
       "npm:@semantic-release/git@^10.0.1",
       "npm:@semantic-release/npm@^12.0.1",
+      "npm:husky@^9.1.7",
       "npm:lightningcss-wasm@^1.29.1",
       "npm:semantic-release@^24.2.3",
       "npm:xxhash-wasm@^1.1.0"

--- a/deno.lock
+++ b/deno.lock
@@ -4,6 +4,7 @@
     "jsr:@david/code-block-writer@^13.0.2": "13.0.3",
     "jsr:@deno/cache-dir@~0.10.3": "0.10.3",
     "jsr:@deno/dnt@~0.41.3": "0.41.3",
+    "jsr:@deno/graph@~0.73.1": "0.73.1",
     "jsr:@std/assert@*": "1.0.11",
     "jsr:@std/assert@0.223": "0.223.0",
     "jsr:@std/assert@0.226": "0.226.0",
@@ -47,6 +48,7 @@
     "@deno/cache-dir@0.10.3": {
       "integrity": "eb022f84ecc49c91d9d98131c6e6b118ff63a29e343624d058646b9d50404776",
       "dependencies": [
+        "jsr:@deno/graph",
         "jsr:@std/fmt@0.223",
         "jsr:@std/fs@0.223",
         "jsr:@std/io",
@@ -63,6 +65,9 @@
         "jsr:@std/path@1",
         "jsr:@ts-morph/bootstrap"
       ]
+    },
+    "@deno/graph@0.73.1": {
+      "integrity": "cd69639d2709d479037d5ce191a422eabe8d71bb68b0098344f6b07411c84d41"
     },
     "@std/assert@0.223.0": {
       "integrity": "eb8d6d879d76e1cc431205bd346ed4d88dc051c6366365b1af47034b0670be24"


### PR DESCRIPTION
Adds commitlint and Husky to enforce conventional commit message formatting.

This ensures consistent and informative commit messages across the project, improving maintainability and collaboration.

Includes:
- Commitlint configuration with conventional commits preset
- Husky hook to run commitlint on commit
- GitHub Actions workflow for commit message validation on push and pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Introduced an automated validation workflow for commit messages.
	- Implemented configuration settings to enforce a maximum commit header length of 160 characters.
	- Updated dependency management to support commit linting and hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->