### PR TITLE
feat: Add ability to ignore selectors/idents via regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,17 +163,61 @@ css-seasoning new-styles.css --conversion-tables tables.json
 
 This ensures that the same mappings are used across multiple CSS files or builds.
 
+#### Example: Ignoring Specific Patterns
+
+You can selectively ignore certain selectors or custom properties that you don't want to transform using regex patterns:
+
+```bash
+# Ignore Bootstrap utility classes starting with 'btn-'
+css-seasoning styles.css --ignore-selector "^btn-"
+
+# Ignore both bootstrap buttons and theme color custom properties
+css-seasoning styles.css --ignore-selector "^btn-" --ignore-ident "^theme-"
+```
+
+Input:
+```css
+:root {
+  --main-color: blue;
+  --theme-primary: red;
+}
+
+.button {
+  color: var(--main-color);
+}
+
+.btn-primary {
+  color: var(--theme-primary);
+}
+```
+
+Output with ignore patterns:
+```css
+:root {
+  --a:blue; --theme-primary:red;
+}
+.b {
+  color:var(--a);
+}
+.btn-primary {
+  color:var(--theme-primary);
+}
+```
+
+This allows you to keep certain naming conventions intact (like framework-specific class names or theme variables) while still transforming the rest of your CSS.
+
 ## 📖 Config Options Reference
 
-| Option                       | Type                                    | Default                  | Description                                                                                                   |
-| ---------------------------- | --------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------- |
-| `mode`                       | `"hash"` \| `"minimal"` \| `"debug"`    | `"hash"`                 | The transformation mode to use                                                                                |
-| `debugSymbol`                | `string`                                | `"_"`                    | Symbol to use in debug mode                                                                                   |
-| `prefix`                     | `string`                                | `""`                     | Prefix to add after debug symbol in debug mode                                                                |
-| `suffix`                     | `string`                                | `""`                     | Suffix to add at the end in debug mode                                                                        |
-| `seed`                       | `number`                                | `undefined`              | Seed for hash generation in hash mode                                                                         |
-| `conversionTables`           | `{ selector?: {}, ident?: {} }`         | `undefined`              | Predefined conversion tables for selectors and identifiers                                                    |
-| `lightningcssOptions`        | `object`                                | `{ minify: true }`       | Options for the lightningcss transform                                                                        |
+| Option                 | Type                                 | Default      | Description                                                      |
+| ---------------------- | ------------------------------------ | ------------ | ---------------------------------------------------------------- |
+| `mode`                 | `"hash"` \| `"minimal"` \| `"debug"` | `"hash"`     | The transformation mode to use                                   |
+| `debugSymbol`          | `string`                             | `"_"`        | Symbol to use in debug mode                                      |
+| `prefix`               | `string`                             | `""`         | Prefix to add after debug symbol in debug mode                   |
+| `suffix`               | `string`                             | `""`         | Suffix to add at the end in debug mode                           |
+| `seed`                 | `number`                             | `undefined`  | Seed for hash generation in hash mode                            |
+| `ignorePatterns`       | `{selector?: (string \| RegExp)[], ident?: (string \| RegExp)[]}` | `undefined` | Patterns for selectors and custom properties to ignore during transformation |
+| `conversionTables`     | `{ selector?: {}, ident?: {} }`      | `undefined`  | Predefined conversion tables for selectors and identifiers       |
+| `lightningcssOptions`  | `object`                             | `{ minify: true }` | Options for the lightningcss transform                     |
 
 ### All options in one place 📦
 
@@ -189,6 +233,10 @@ const result = transform({
   prefix: "prefix-",     // Prefix in debug mode (after symbol)
   suffix: "-suffix",     // Suffix in debug mode
   seed: 123,             // Custom seed for hash generation
+  ignorePatterns: {      // Patterns to ignore during transformation
+    selector: ["^btn-", /header$/],
+    ident: ["^theme-"]
+  },
   conversionTables: {    // Optional reusable mappings
     selector: { "\\.button": "\\.preserved-class" },
     ident: { "color": "preserved-var" }

--- a/cli.ts
+++ b/cli.ts
@@ -27,11 +27,14 @@ OPTIONS:
   --source-map                 Generate source map
   --conversion-tables <file>   JSON file with existing conversion tables to preserve mappings
   --save-tables <file>         Save the conversion tables to a JSON file (prints to stderr if not specified)
+  --ignore-selector <pattern>  Regex pattern for selectors to ignore (can be used multiple times)
+  --ignore-ident <pattern>     Regex pattern for custom properties to ignore (can be used multiple times)
 
 EXAMPLES:
   css-seasoning styles.css
   css-seasoning -o output.css -m minimal styles.css
   css-seasoning --mode debug --debug-symbol "_d_" styles.css
+  css-seasoning --ignore-selector "^btn-" --ignore-ident "^theme-" styles.css
   `);
 };
 
@@ -40,8 +43,12 @@ EXAMPLES:
  */
 const parseArgsa = () => {
   const args = jsrParseArgs(Deno.args, {
-    string: ["output", "mode", "debug-symbol", "prefix", "suffix", "seed", "conversion-tables", "save-tables"],
-    boolean: ["help", "minify", "source-map"],
+    string: ["output", "mode", "debug-symbol", "prefix", "suffix", "seed", "conversion-tables", "save-tables", "ignore-selector", "ignore-ident"],
+    boolean: [
+      "help", 
+      "minify", 
+      "source-map"
+    ],
     alias: {
       h: "help",
       o: "output",
@@ -57,6 +64,7 @@ const parseArgsa = () => {
       suffix: "",
       minify: true,
     },
+    collect: ["ignore-selector", "ignore-ident"],
   });
 
   if (args.help || args._.length === 0) {
@@ -81,6 +89,8 @@ const parseArgsa = () => {
     sourceMap: args["source-map"],
     conversionTablesFile: args["conversion-tables"],
     saveTablesFile: args["save-tables"],
+    ignoreSelectorPatterns: args["ignore-selector"] as string[],
+    ignoreIdentPatterns: args["ignore-ident"] as string[],
   };
 };
 
@@ -118,6 +128,10 @@ const main = async () => {
       suffix: options.suffix,
       seed: options.seed,
       conversionTables: existingConversionTables,
+      ignorePatterns: {
+        selector: options.ignoreSelectorPatterns,
+        ident: options.ignoreIdentPatterns,
+      },
       lightningcssOptions: {
         minify: options.minify,
         sourceMap: options.sourceMap,

--- a/cli.ts
+++ b/cli.ts
@@ -76,7 +76,7 @@ const parseArgsa = () => {
     debugSymbol: args["debug-symbol"],
     prefix: args.prefix,
     suffix: args.suffix,
-    seed: args.seed ? parseInt(args.seed) : undefined,
+    seed: args.seed ? Number.parseInt(args.seed) : undefined,
     minify: args.minify,
     sourceMap: args["source-map"],
     conversionTablesFile: args["conversion-tables"],
@@ -146,7 +146,7 @@ const main = async () => {
       console.log(`Conversion tables saved to ${options.saveTablesFile}`);
     } else {
       // Print conversion tables to stderr
-      console.log(`\nConversion Tables:`);
+      console.log("\nConversion Tables:");
       console.log(JSON.stringify(result.conversionTables, null, 2));
     }
 

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -5,6 +5,7 @@ import {
   generateHash,
   initializeHash,
   isNArray,
+  matchesAnyPattern,
   numberToLetters,
   parseSelectorComponent,
   stringifySelectorComponent,
@@ -158,4 +159,32 @@ Deno.test("Array level detection works correctly", () => {
   assertEquals(isNArray([[[1]]], 3), true);
   assertEquals(isNArray([], 1), true);
   assertEquals(isNArray("not an array", 1), false);
+});
+
+// Tests for matchesAnyPattern function
+Deno.test("matchesAnyPattern identifies matching patterns correctly", () => {
+  // Test with string patterns
+  assertEquals(matchesAnyPattern("test", ["test"]), true);
+  assertEquals(matchesAnyPattern("test", ["other"]), false);
+  assertEquals(matchesAnyPattern("test123", ["test\\d+"]), true);
+
+  // Test with RegExp patterns
+  assertEquals(matchesAnyPattern("test", [/^test$/]), true);
+  assertEquals(matchesAnyPattern("test", [/^t.st$/]), true);
+  assertEquals(matchesAnyPattern("test", [/^other$/]), false);
+
+  // Test with mixed patterns
+  assertEquals(matchesAnyPattern("test", ["other", /^test$/]), true);
+  assertEquals(matchesAnyPattern("test", [/^other$/, "test"]), true);
+
+  // Test with multiple matches
+  assertEquals(matchesAnyPattern("test", ["test", /^test$/]), true);
+
+  // Test with empty or undefined patterns
+  assertEquals(matchesAnyPattern("test", []), false);
+  assertEquals(matchesAnyPattern("test", undefined), false);
+
+  // Test case sensitivity
+  assertEquals(matchesAnyPattern("Test", ["test"]), false);
+  assertEquals(matchesAnyPattern("Test", [/test/i]), true);
 });

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -73,8 +73,7 @@ const INTERNAL_handleSelector = (
             }
           } else {
             throw new Error(
-              `Unhandled component stringify: ${
-                JSON.stringify(component)
+              `Unhandled component stringify: ${JSON.stringify(component)
               }, the "${component.type}" type should be handled.`,
             );
           }
@@ -180,103 +179,108 @@ const createConversionFunction = (
     ) => string;
   },
 ) => string => {
-  if (mode === "minimal") {
-    let minimalCounter = 0;
-    return (
-      value: string,
-      conversionTable: Record<string, string>,
-      options?: {
-        onExistenceFound?: (
-          originalValue: string,
-          convertToValue: string,
-        ) => string;
-        onNewValueBeforeAdd?: (
-          originalValue: string,
-          valueToSave: string,
-        ) => string;
-      },
-    ) => {
-      const escaped = cssEscape(value);
-      if (conversionTable[escaped]) {
-        const convertToValue = conversionTable[escaped];
-        if (options?.onExistenceFound) {
-          return options.onExistenceFound(value, convertToValue);
+  switch (mode) {
+    case "minimal": {
+      let minimalCounter = 0;
+      return (
+        value: string,
+        conversionTable: Record<string, string>,
+        options?: {
+          onExistenceFound?: (
+            originalValue: string,
+            convertToValue: string,
+          ) => string;
+          onNewValueBeforeAdd?: (
+            originalValue: string,
+            valueToSave: string,
+          ) => string;
+        },
+      ) => {
+        const escaped = cssEscape(value);
+        if (conversionTable[escaped]) {
+          const convertToValue = conversionTable[escaped];
+          if (options?.onExistenceFound) {
+            return options.onExistenceFound(value, convertToValue);
+          }
+          return convertToValue;
         }
-        return convertToValue;
-      }
-      const newVal = prefix + numberToLetters(minimalCounter) + suffix;
-      minimalCounter++;
-      conversionTable[escaped] = cssEscape(
-        options?.onNewValueBeforeAdd
-          ? options.onNewValueBeforeAdd(value, newVal)
-          : newVal,
-      );
-      return newVal;
-    };
-  } else if (mode === "debug") {
-    return (
-      value: string,
-      conversionTable: Record<string, string>,
-      options?: {
-        onExistenceFound?: (
-          originalValue: string,
-          convertToValue: string,
-        ) => string;
-        onNewValueBeforeAdd?: (
-          originalValue: string,
-          valueToSave: string,
-        ) => string;
-      },
-    ) => {
-      const escaped = cssEscape(value);
-      if (conversionTable[escaped]) {
-        const convertToValue = conversionTable[escaped];
-        if (options?.onExistenceFound) {
-          return options.onExistenceFound(value, convertToValue);
+        const newVal = prefix + numberToLetters(minimalCounter) + suffix;
+        minimalCounter++;
+        conversionTable[escaped] = cssEscape(
+          options?.onNewValueBeforeAdd
+            ? options.onNewValueBeforeAdd(value, newVal)
+            : newVal,
+        );
+        return newVal;
+      };
+    }
+    case "debug": {
+      return (
+        value: string,
+        conversionTable: Record<string, string>,
+        options?: {
+          onExistenceFound?: (
+            originalValue: string,
+            convertToValue: string,
+          ) => string;
+          onNewValueBeforeAdd?: (
+            originalValue: string,
+            valueToSave: string,
+          ) => string;
+        },
+      ) => {
+        const escaped = cssEscape(value);
+        if (conversionTable[escaped]) {
+          const convertToValue = conversionTable[escaped];
+          if (options?.onExistenceFound) {
+            return options.onExistenceFound(value, convertToValue);
+          }
+          return convertToValue;
         }
-        return convertToValue;
-      }
-      const newVal = debugSymbol + prefix + value + suffix;
-      conversionTable[escaped] = cssEscape(
-        options?.onNewValueBeforeAdd
-          ? options.onNewValueBeforeAdd(value, newVal)
-          : newVal,
-      );
-      return newVal;
-    };
-  } else {
-    // hash mode
-    const localSeed = seed;
-    return (
-      value: string,
-      conversionTable: Record<string, string>,
-      options?: {
-        onExistenceFound?: (
-          originalValue: string,
-          convertToValue: string,
-        ) => string;
-        onNewValueBeforeAdd?: (
-          originalValue: string,
-          valueToSave: string,
-        ) => string;
-      },
-    ) => {
-      const escaped = cssEscape(value);
-      if (conversionTable[escaped]) {
-        const convertToValue = conversionTable[escaped];
-        if (options?.onExistenceFound) {
-          return options.onExistenceFound(value, convertToValue);
+        const newVal = debugSymbol + prefix + value + suffix;
+        conversionTable[escaped] = cssEscape(
+          options?.onNewValueBeforeAdd
+            ? options.onNewValueBeforeAdd(value, newVal)
+            : newVal,
+        );
+        return newVal;
+      };
+    }
+    case "hash": {
+      const localSeed = seed;
+      return (
+        value: string,
+        conversionTable: Record<string, string>,
+        options?: {
+          onExistenceFound?: (
+            originalValue: string,
+            convertToValue: string,
+          ) => string;
+          onNewValueBeforeAdd?: (
+            originalValue: string,
+            valueToSave: string,
+          ) => string;
+        },
+      ) => {
+        const escaped = cssEscape(value);
+        if (conversionTable[escaped]) {
+          const convertToValue = conversionTable[escaped];
+          if (options?.onExistenceFound) {
+            return options.onExistenceFound(value, convertToValue);
+          }
+          return convertToValue;
         }
-        return convertToValue;
-      }
-      const hashValue = prefix + generateHash(value, localSeed) + suffix;
-      conversionTable[escaped] = cssEscape(
-        options?.onNewValueBeforeAdd
-          ? options.onNewValueBeforeAdd(value, hashValue)
-          : hashValue,
-      );
-      return hashValue;
-    };
+        const hashValue = prefix + generateHash(value, localSeed) + suffix;
+        conversionTable[escaped] = cssEscape(
+          options?.onNewValueBeforeAdd
+            ? options.onNewValueBeforeAdd(value, hashValue)
+            : hashValue,
+        );
+        return hashValue;
+      };
+    }
+    default:
+      throw new Error(`Unknown mode: ${mode}`);
   }
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,24 @@ export interface TransformProps {
    * Use if you want to preserve previous mappings.
    */
   conversionTables?: Partial<ConversionTables>;
+  /**
+   * Patterns to ignore when transforming CSS.
+   * Any selector or custom property that matches one of the patterns will be left unchanged.
+   */
+  ignorePatterns?: {
+    /**
+     * Patterns for selectors to ignore during transformation.
+     * Any selector that matches one of these regular expressions will be left unchanged.
+     * Patterns should match the selector name without the prefix (e.g., "button" for ".button").
+     */
+    selector?: (string | RegExp)[];
+    /**
+     * Patterns for custom properties (identifiers) to ignore during transformation.
+     * Any custom property that matches one of these regular expressions will be left unchanged.
+     * Patterns should match the property name without the '--' prefix (e.g., "color" for "--color").
+     */
+    ident?: (string | RegExp)[];
+  };
   lightningcssOptions?: Omit<
     TransformOptions<CustomAtRules>,
     | "filename"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -341,3 +341,34 @@ export const isNArray = <T>(arr: T | T[], level: number): arr is T[] => {
   }
   return isNArray(arr[0], level - 1);
 };
+
+/**
+ * Checks if a value matches any of the provided regex patterns.
+ *
+ * @param value - The string value to check.
+ * @param patterns - Array of string or RegExp patterns to match against.
+ * @returns True if the value matches any pattern, false otherwise.
+ *
+ * @example
+ * ```ts
+ * matchesAnyPattern("test", [/^test$/]); // true
+ * matchesAnyPattern("test", ["test"]); // true
+ * matchesAnyPattern("test", [/^foo$/]); // false
+ * matchesAnyPattern("test", ["bar"]); // false
+ * ```
+ */
+export const matchesAnyPattern = (
+  value: string,
+  patterns?: (string | RegExp)[],
+): boolean => {
+  if (!patterns || patterns.length === 0) {
+    return false;
+  }
+
+  return patterns.some((pattern) => {
+    if (typeof pattern === "string") {
+      return new RegExp(pattern).test(value);
+    }
+    return pattern.test(value);
+  });
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for ignoring specific CSS selectors and custom properties during transformation using string or regex patterns. This allows users to exclude certain classes or variables from being changed.
  - New CLI options `--ignore-selector` and `--ignore-ident` enable pattern-based exclusions directly from the command line.
  - Updated documentation with examples and configuration details for the new ignore functionality.

- **Bug Fixes**
  - None.

- **Tests**
  - Added comprehensive tests to verify correct behavior of the ignore patterns feature for selectors and custom properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->