### PR TITLE
feat(types): Adds JSDoc comments to types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -24,8 +24,8 @@ export interface ConversionTables {
    * Mapping for identifier conversion.
    *
    * ## **Note**
-   * Make sure the keys are **escaped** properly
-   * and without the '--' prefix.
+   * Make sure the keys are **escaped** properly.
+   * Ensure they do not include the `--` prefix.
    */
   ident: ConversionTable;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,16 @@
 import type { CustomAtRules, TransformOptions } from "lightningcss-wasm";
 
+/**
+ * Represents a conversion table.
+ * A mapping of original strings to their converted counterparts.
+ * The keys are the original strings, and the values are the converted strings.
+ */
 export type ConversionTable = Record<string, string>;
 
+/**
+ * Represents a group of conversion tables supported by this package.
+ * This includes both selector and identifier conversion tables.
+ */
 export interface ConversionTables {
   /**
    * Mapping for selector conversion.
@@ -10,6 +19,7 @@ export interface ConversionTables {
    * Make sure the keys are **escaped** properly.
    */
   selector: ConversionTable;
+
   /**
    * Mapping for identifier conversion.
    *
@@ -21,17 +31,47 @@ export interface ConversionTables {
 }
 
 export interface TransformProps {
+  /**
+   * The CSS code to be transformed.
+   */
   css: string;
+
+  /**
+   * The mode of transformation.
+   * - `hash`: Generates a reproducible hash for each selector and identifier.
+   * - `minimal`: Minimizes the key into an alphanumeric string (e.g., "a", "b", "c"...)
+   * - `debug`: Won't change the targeted selectors or identifiers fully but prefixes them with a debug symbol.
+   */
   mode?: "hash" | "minimal" | "debug";
+
+  /**
+   * The debug symbol to be used in debug mode.
+   * This symbol will be prepended to the transformed selectors and identifiers.
+   */
   debugSymbol?: string;
+
+  /**
+   * The prefix to be prepended to transformed selectors and identifiers.
+   */
   prefix?: string;
+
+  /**
+   * The suffix to be appended to transformed selectors and identifiers.
+   */
   suffix?: string;
+
+  /**
+   * The seed to be used for hash generation.
+   * This is useful for generating consistent hashes across different runs.
+   */
   seed?: number;
+
   /**
    * Predefined conversion tables for selectors and identifiers.
    * Use if you want to preserve previous mappings.
    */
   conversionTables?: Partial<ConversionTables>;
+
   /**
    * Patterns to ignore when transforming CSS.
    * Any selector or custom property that matches one of the patterns will be left unchanged.
@@ -43,6 +83,7 @@ export interface TransformProps {
      * Patterns should match the selector name without the prefix (e.g., "button" for ".button").
      */
     selector?: (string | RegExp)[];
+
     /**
      * Patterns for custom properties (identifiers) to ignore during transformation.
      * Any custom property that matches one of these regular expressions will be left unchanged.
@@ -50,6 +91,10 @@ export interface TransformProps {
      */
     ident?: (string | RegExp)[];
   };
+
+  /**
+   * Options for the LightningCSS transformation.
+   */
   lightningcssOptions?: Omit<
     TransformOptions<CustomAtRules>,
     | "filename"
@@ -59,7 +104,14 @@ export interface TransformProps {
 }
 
 export interface TransformResult {
+  /**
+   * The transformed CSS code.
+   */
   css: string;
+
+  /**
+   * The conversion tables used during the transformation.
+   */
   conversionTables: ConversionTables;
 }
 


### PR DESCRIPTION
Adds JSDoc comments to the types used in the project.

This improves the developer experience by providing more context and documentation for the different types. It clarifies the purpose of each property and interface, making the code easier to understand and use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added detailed descriptions and usage notes to all types and interfaces, improving clarity and usability for developers. No changes to functionality or type definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->