### PR TITLE
feat: Allow string seeds for consistent hashing

### DIFF
--- a/src/__tests__/transformer.test.ts
+++ b/src/__tests__/transformer.test.ts
@@ -122,12 +122,36 @@ Deno.test("transform - custom seed in hash mode", () => {
     seed: 2,
     lightningcssOptions: { minify: false },
   });
+  const stringSeedResult = transform({
+    css: input,
+    seed: "seed1", // Use a string seed
+    lightningcssOptions: { minify: false },
+  });
+  const stringSeedResult2 = transform({
+    css: input,
+    seed: "seed1", // Same string seed
+    lightningcssOptions: { minify: false },
+  });
+  const stringSeedResult3 = transform({
+    css: input,
+    seed: "seed2", // Different string seed
+    lightningcssOptions: { minify: false },
+  });
 
-  // Check if the same seed produces the same output
+  // Check if the same numeric seed produces the same output
   assertEquals(seed1Result.css, seed1Result2.css);
 
-  // Different seeds should produce different outputs
+  // Different numeric seeds should produce different outputs
   assertNotEquals(seed1Result.css, seed2Result.css);
+
+  // Check if the same string seed produces the same output
+  assertEquals(stringSeedResult.css, stringSeedResult2.css);
+
+  // Different string seeds should produce different outputs
+  assertNotEquals(stringSeedResult.css, stringSeedResult3.css);
+
+  // Numeric seed 1 and string seed "seed1" should produce different outputs
+  assertNotEquals(seed1Result.css, stringSeedResult.css);
 });
 
 Deno.test("transform - preserves conversion tables", () => {

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -194,5 +194,9 @@ Deno.test("stringSeedToNumber converts string seeds correctly", () => {
   assertEquals(stringSeedToNumber("a"), 97);
   assertEquals(stringSeedToNumber("abc"), 97 + 98 + 99); // 294
   assertEquals(stringSeedToNumber(""), 0);
-  assertEquals(stringSeedToNumber("seed1"), "s".charCodeAt(0) + "e".charCodeAt(0) + "e".charCodeAt(0) + "d".charCodeAt(0) + "1".charCodeAt(0));
+  assertEquals(
+    stringSeedToNumber("seed1"),
+    "s".charCodeAt(0) + "e".charCodeAt(0) + "e".charCodeAt(0) +
+      "d".charCodeAt(0) + "1".charCodeAt(0),
+  );
 });

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -10,6 +10,7 @@ import {
   parseSelectorComponent,
   stringifySelectorComponent,
   stringifySelectorComponentComplex,
+  stringSeedToNumber,
 } from "@/utils.ts";
 
 // Initialize hash before tests
@@ -187,4 +188,11 @@ Deno.test("matchesAnyPattern identifies matching patterns correctly", () => {
   // Test case sensitivity
   assertEquals(matchesAnyPattern("Test", ["test"]), false);
   assertEquals(matchesAnyPattern("Test", [/test/i]), true);
+});
+
+Deno.test("stringSeedToNumber converts string seeds correctly", () => {
+  assertEquals(stringSeedToNumber("a"), 97);
+  assertEquals(stringSeedToNumber("abc"), 97 + 98 + 99); // 294
+  assertEquals(stringSeedToNumber(""), 0);
+  assertEquals(stringSeedToNumber("seed1"), "s".charCodeAt(0) + "e".charCodeAt(0) + "e".charCodeAt(0) + "d".charCodeAt(0) + "1".charCodeAt(0));
 });

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -17,6 +17,7 @@ import {
   numberToLetters,
   parseSelectorComponent,
   stringifySelectorComponent,
+  stringSeedToNumber,
 } from "@/utils.ts";
 
 export const initTransform = async () => {
@@ -160,7 +161,7 @@ const INTERNAL_handleSelector = (
  * @param debugSymbol - Symbol used for debugging (only applicable in 'debug' mode).
  * @param prefix - Prefix to display after the debug symbol in debug mode.
  * @param suffix - Suffix to append after the converted value in debug mode.
- * @param seed - Optional seed used for hashing in 'hash' mode.
+ * @param seed - Optional numeric seed used for hashing in 'hash' mode.
  * @returns A function that converts a string using the given mode.
  */
 const createConversionFunction = (
@@ -399,7 +400,7 @@ const normalizeAffixOptions = (
  * @param params.debugSymbol - The custom debug symbol to prefix in debug mode; defaults to '_' if not provided.
  * @param params.prefix - In debug mode, the prefix to display after the debug symbol; defaults to an empty string.
  * @param params.suffix - In debug mode, the suffix to append after the value; defaults to an empty string.
- * @param params.seed - The custom seed for hash mode; defaults to 125 if not provided.
+ * @param params.seed - The custom seed (string or number) for hash mode.
  * @param params.conversionTables - Predefined conversion tables for selectors and identifiers. Use if you want to preserve previous mappings.
  * @param params.ignorePatterns - Patterns for selectors and custom properties to ignore during transformation.
  * @param params.lightningcssOptions - Options for the lightningcss transform.
@@ -428,13 +429,16 @@ export const transform: Transform = ({
   const normalizedPrefix = normalizeAffixOptions(prefix);
   const normalizedSuffix = normalizeAffixOptions(suffix);
 
+  // Convert string seed to number if necessary
+  const numericSeed = typeof seed === "string" ? stringSeedToNumber(seed) : seed;
+
   // Create conversion functions based on the selected mode and custom seed
   const selectorConvertFunc = createConversionFunction(
     mode,
     debugSymbol,
     normalizedPrefix.selectors,
     normalizedSuffix.selectors,
-    seed,
+    numericSeed,
   );
 
   const identConvertFunc = createConversionFunction(
@@ -442,7 +446,7 @@ export const transform: Transform = ({
     debugSymbol,
     normalizedPrefix.idents,
     normalizedSuffix.idents,
-    seed,
+    numericSeed,
   );
 
   // Build visitor for lightningcss.Transform using provided conversion tables

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -430,7 +430,9 @@ export const transform: Transform = ({
   const normalizedSuffix = normalizeAffixOptions(suffix);
 
   // Convert string seed to number if necessary
-  const numericSeed = typeof seed === "string" ? stringSeedToNumber(seed) : seed;
+  const numericSeed = typeof seed === "string"
+    ? stringSeedToNumber(seed)
+    : seed;
 
   // Create conversion functions based on the selected mode and custom seed
   const selectorConvertFunc = createConversionFunction(

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,8 +86,9 @@ export interface TransformProps {
   /**
    * The seed to be used for hash generation.
    * This is useful for generating consistent hashes across different runs.
+   * Can be a string or a number.
    */
-  seed?: number;
+  seed?: string | number;
 
   /**
    * Predefined conversion tables for selectors and identifiers.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,6 +20,20 @@ const LOWERCASE_A_CHARCODE = 97;
 const LOWERCASE_Z_CHARCODE = 122;
 
 /**
+ * Converts a string seed into a numeric seed by summing character codes.
+ *
+ * @param strSeed - The string seed to convert.
+ * @returns A numeric representation of the string seed.
+ */
+export const stringSeedToNumber = (strSeed: string): number => {
+  let numSeed = 0;
+  for (let i = 0; i < strSeed.length; i++) {
+    numSeed += strSeed.charCodeAt(i);
+  }
+  return numSeed;
+};
+
+/**
  * Generates a hash value from a string.
  *
  * @param value - The string to hash.


### PR DESCRIPTION
Enables the use of string seeds in addition to numeric seeds for generating consistent hash values.

This provides greater flexibility in controlling the output of the transformation process, especially when a memorable or easily configurable seed is desired. A utility function is added to convert the string seed to a numeric value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for using string values as seeds in the transformation process, in addition to numeric seeds.

- **Bug Fixes**
  - Ensured consistent transformation results when using the same string seed and distinct results for different seeds.

- **Tests**
  - Expanded test coverage to verify correct handling of string seeds and the conversion logic from string seeds to numeric values.

- **Documentation**
  - Updated type definitions and comments to reflect support for both string and numeric seeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->