### PR TITLE
feat: Enhance selector handling for various CSS components and pseudo…

### DIFF
--- a/src/__tests__/transformer.test.ts
+++ b/src/__tests__/transformer.test.ts
@@ -185,13 +185,13 @@ Deno.test("transform - preserves conversion tables", () => {
   // Check if existing mappings are preserved
   assertEquals(
     result.conversionTables.selectors[
-    Object.keys(existingTables.selectors)[0]
+      Object.keys(existingTables.selectors)[0]
     ],
     Object.values(existingTables.selectors)[0],
   );
   assertEquals(
     result.conversionTables.idents[
-    Object.keys(existingTables.idents)[0]
+      Object.keys(existingTables.idents)[0]
     ],
     Object.values(existingTables.idents)[0],
   );

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -96,7 +96,8 @@ const INTERNAL_handleSelector = (
             }
           } else {
             throw new Error(
-              `Unhandled component stringify: ${JSON.stringify(component)
+              `Unhandled component stringify: ${
+                JSON.stringify(component)
               }, the "${component.type}" type should be handled.`,
             );
           }
@@ -441,7 +442,7 @@ export const transform: Transform = ({
   // Use user provided conversion tables if available, otherwise create new ones
   const selectorConversionTable: ConversionTable =
     conversionTables?.selectors ??
-    {};
+      {};
   const identConversionTable: ConversionTable = conversionTables?.idents ?? {};
 
   // Normalize prefix and suffix to get separate values for selectors and identifiers


### PR DESCRIPTION
…-classes

## Summary by Sourcery

Enhance the CSS transformer to gracefully support a wide range of selector types and pseudo-classes by passing them through unchanged, and add extensive tests to verify their correct handling.

New Features:
- Extend selector transformation to handle universal, attribute, combinator, namespace, nesting, and pseudo-element selectors without modification
- Add support for various pseudo-classes (disabled, first-child, last-child, nth-child, nth-last-child, focus, focus-within, focus-visible, root, and custom) in the transformer

Enhancements:
- Refactor INTERNAL_handleSelector to explicitly pass through newly supported selector types and pseudo-classes
- Streamline error message formatting in selector handling

Tests:
- Add comprehensive tests for each newly supported selector type and pseudo-class to ensure correct CSS output and conversion tables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded test coverage for CSS selector transformations, including numerous pseudo-classes, pseudo-elements, combinators, attribute selectors, and complex selector scenarios to ensure accurate handling and naming.
  - Improved formatting consistency in test cases.

- **Bug Fixes**
  - Enhanced handling of various CSS selector types and pseudo-classes to ensure correct processing and preservation during transformations.
  - Improved error handling and internal consistency for unhandled selector components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->