### PR TITLE
fix: fix incorrect cli calling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: deno run --allow-env semantic-release
+        run: deno run --allow-all semantic-release
 
       - name: Run Dry Release
         if: github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: deno run --allow-env semantic-release --dry-run
+        run: deno run --allow-all semantic-release --dry-run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: deno run semantic-release
+        run: deno run --allow-env semantic-release
 
       - name: Run Dry Release
         if: github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: deno run semantic-release --dry-run
+        run: deno run --allow-env semantic-release --dry-run

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
 
-import { cli } from "../dist/npm/esm/cli.js";
+import { cli } from "../esm/cli.js";
 
 cli();

--- a/scripts/build-npm.ts
+++ b/scripts/build-npm.ts
@@ -3,6 +3,25 @@ import pkg from "../deno.json" with { type: "json" }
 
 const BASE_PATH = "./dist/npm";
 
+/**
+ * Recursively copy all files and subfolders from src to dest.
+ * @param src - Source directory path
+ * @param dest - Destination directory path
+ */
+const copyDir = (src: string, dest: string) => {
+  Deno.mkdirSync(dest, { recursive: true });
+  for (const entry of Deno.readDirSync(src)) {
+  const srcPath = `${src}/${entry.name}`;
+  const destPath = `${dest}/${entry.name}`;
+  if (entry.isFile) {
+    Deno.copyFileSync(srcPath, destPath);
+  } else if (entry.isDirectory) {
+    copyDir(srcPath, destPath);
+  }
+  }
+};
+
+
 await emptyDir(`${BASE_PATH}`);
 
 await build({
@@ -39,5 +58,8 @@ await build({
     Deno.copyFileSync("LICENSE", `${BASE_PATH}/LICENSE`);
     Deno.copyFileSync("README.md", `${BASE_PATH}/README.md`);
     Deno.copyFileSync(".npmignore", `${BASE_PATH}/.npmignore`);
+
+    Deno.mkdirSync(`${BASE_PATH}/bin`, { recursive: true });
+    copyDir("./bin", `${BASE_PATH}/bin`);
   },
 });


### PR DESCRIPTION
## Summary by Sourcery

Include CLI scripts in the npm package by copying the local bin directory into the build output

Bug Fixes:
- Fix missing CLI files in the npm package by packaging the bin directory

Enhancements:
- Add a recursive copyDir helper to copy directories and their contents
- Create the dist bin folder and copy all bin scripts during the npm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Ensures the CLI is included and works correctly when installed from npm.
  - Adjusted CLI import path to improve reliability across environments.

- Chores
  - Updated build process to include CLI assets in the npm package.
  - Release automation adjusted to run with expanded permissions for release and dry-run flows.

- Documentation
  - None.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->